### PR TITLE
Lock 2 KiB bootloader region

### DIFF
--- a/flash-bootloader.gdb
+++ b/flash-bootloader.gdb
@@ -2,6 +2,8 @@ file bootloader.elf
 target extended-remote /dev/ttyACM0
 monitor swdp_scan
 attach 1
+monitor unlock_bootprot
 monitor erase_mass
 load
+monitor lock_bootprot 4
 kill


### PR DESCRIPTION
Prevents firmware from accidentally overwriting the bootloader. The magic number `4` configures `BOOTPROTO` to protect a 2 KiB region, defined in the SAMD11 datasheet and confirmed experimentally.