### PR TITLE
Add calibration system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ test: $(TIMESTAMP)
 debug: $(TIMESTAMP)
 	$(ENV_PYTHON) cynthion-test.py debug
 
+calibrate: $(TIMESTAMP)
+	$(ENV_PYTHON) calibrate.py
+
 bootloader: bootloader.elf
 
 bootloader.elf: $(BOOTLOADER)

--- a/calibrate.py
+++ b/calibrate.py
@@ -17,6 +17,8 @@ def calibrate():
     # Power TARGET-C at 5V and calibrate lower range.
     with group("Calibrating low range"):
         set_boost_supply(5.0, 0.1)
+        # Boost converter needs a moment to stabilise on first startup.
+        sleep(0.1)
         scale_low = 5.0 / test_vbus('TARGET-C', Range(4.9, 5.1))
         item(f"Calibration factor: {info(scale_low)}")
 

--- a/calibrate.py
+++ b/calibrate.py
@@ -25,7 +25,7 @@ def calibrate():
     # Increase voltage to 15V and repeat.
     with group("Calibrating high range"):
         set_boost_supply(15.0, 0.1)
-        scale_high = 15.0 / test_vbus('TARGET-C', Range(14.8, 15.2))
+        scale_high = 15.0 / test_vbus('TARGET-C', Range(14.5, 15.5))
         item(f"Calibration factor: {info(scale_high)}")
 
     # Write out calibration.

--- a/calibrate.py
+++ b/calibrate.py
@@ -1,0 +1,42 @@
+from tests import *
+import tests
+import pickle
+
+def calibrate():
+    # Use a dummy calibration while taking uncalibrated measurements.
+    tests.calibration = dict(
+        voltage_scale_upper = 1.0,
+        voltage_scale_lower = 1.0
+    )
+
+    # Have user disconnect TARGET-C cable so we can power it without a load.
+    # Using TARGET-C because it won't power up the EUT if they get it wrong.
+    request("disconnect TARGET-C cable from EUT")
+    connect_boost_supply_to('TARGET-C')
+
+    # Power TARGET-C at 5V and calibrate lower range.
+    with group("Calibrating low range"):
+        set_boost_supply(5.0, 0.1)
+        scale_low = 5.0 / test_vbus('TARGET-C', Range(4.9, 5.1))
+        item(f"Calibration factor: {info(scale_low)}")
+
+    # Increase voltage to 15V and repeat.
+    with group("Calibrating high range"):
+        set_boost_supply(15.0, 0.1)
+        scale_high = 15.0 / test_vbus('TARGET-C', Range(14.8, 15.2))
+        item(f"Calibration factor: {info(scale_high)}")
+
+    # Write out calibration.
+    calibration = dict(
+        voltage_scale_lower=scale_low,
+        voltage_scale_upper=scale_high,
+    )
+    pickle.dump(calibration, open('calibration.dat', 'wb'))
+
+if __name__ == "__main__":
+    try:
+        calibrate()
+        ok("Calibration complete")
+    except KeyboardInterrupt:
+        fail("Calibration stopped by user")
+    reset()

--- a/cynthion-test.py
+++ b/cynthion-test.py
@@ -3,6 +3,9 @@ import ipdb
 import sys
 
 def test():
+    # Load calibration data.
+    load_calibration()
+
     # Bring up boost converter so that VBUS switches work correctly.
     set_boost_supply(5.0, 0.1)
 


### PR DESCRIPTION
This PR adds a simple calibration system, which uses the DC-DC supply as a reference to calibrate Tycho's voltage measurements. This supply is used because the TPS55288 voltage reference is specified for +/- 1% accuracy, which makes it the most accurate reference available on the board.

To calibrate, the Target-C cable is first disconnected from the EUT, such that there is no load on Tycho's Target-C port. Then the DC-DC converter is connected to Tycho's Target-C port, set to a reference voltage, and measured as normal. This measurement is performed separately for the low (<= 6.6 V) and high (>= 6.6V) voltage ranges, i.e. with or without R65 switched in via Q18. For each range, a scale factor is calculated to correct the measured value to the expected value.

The two resulting scale factors represent the combined effects of inaccuracies in:

- The GreatFET 3.3V regulator output voltage, which is the reference for the ADC.
- The R63/R64(/R65) voltage divider ratios, which depend on the precise values of those resistors.

As such they are specific to a given Tycho/GreatFET pair, and should be re-calibrated if either is changed.

Use `make calibrate` to run the calibration. Running `make test` will fail if a valid calibration is not found.