### PR TITLE
Add unattended test mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ test: $(TIMESTAMP)
 debug: $(TIMESTAMP)
 	$(ENV_PYTHON) cynthion-test.py debug
 
+unattended: $(TIMESTAMP)
+	$(ENV_PYTHON) cynthion-test.py unattended
+
 calibrate: $(TIMESTAMP)
 	$(ENV_PYTHON) calibrate.py
 

--- a/cynthion-test.py
+++ b/cynthion-test.py
@@ -176,12 +176,12 @@ def test():
 
     # Check that the Target-A cable is connected.
     with group("Checking Target-A cable is connected"):
-        set_boost_supply(5.0, 0.25)
-        connect_boost_supply_to('TARGET-C')
         test_target_a_cable(True)
 
     # Check that the FX2 enumerates through the passthrough.
     with group("Testing Target-C to Target-A data passthrough"):
+        set_boost_supply(5.0, 0.25)
+        connect_boost_supply_to('TARGET-C')
         connect_host_to('TARGET-C')
         FX2_EN.high()
         loader = test_fx2_present()

--- a/tests.py
+++ b/tests.py
@@ -1187,16 +1187,14 @@ def test_target_a_cable(required):
     incorrect = "disconnected" if required else "connected"
     with group(f"Checking {info('TARGET-A')} cable is {info(correct)}"):
         try:
-            if required:
-                test_vbus('TARGET-A', Range(4.85, 5.05))
-            else:
-                with task(f"Pulling {info('TARGET-A')} up to {info('3.3 V')}"):
-                    mux_select('VBUS_TA')
-                    V_DIV.high()
-                test_voltage('TARGET_A_VBUS', Range(0, 0.1))
-                with task(f"Releasing {info('TARGET-A')} pullup"):
-                    V_DIV.low()
-                    mux_disconnect()
+            with task(f"Pulling {info('TARGET-A')} up to {info('3.3 V')}"):
+                mux_select('VBUS_TA')
+                V_DIV.high()
+            expected = Range(0.1, 1.0) if required else Range(0, 0.1)
+            test_voltage('TARGET_A_VBUS', expected)
+            with task(f"Releasing {info('TARGET-A')} pullup"):
+                V_DIV.low()
+                mux_disconnect()
             success = True
         except ValueError:
             success = False


### PR DESCRIPTION
This PR adds an unattended mode for the Cynthion factory test.

This mode is not intended to be used in production, but is useful for debugging as it allows running the test repeatedly without user interaction to try to trigger intermittent failures. It should also be useful for CI testing.

This version of the test can be run with `make unattended`. The Target-A cable should be connected.

The unattended test will skip:

- HS speed test to the TARGET PHY. 
- Visual check of LEDs.
- Physical tests of the USER, RESET and PROGRAM buttons.

All other test steps are run as normal.