### PR TITLE
Avoid host supply

### DIFF
--- a/cynthion-test.py
+++ b/cynthion-test.py
@@ -184,8 +184,9 @@ def test(user_present: bool):
 
     # Check that the FX2 enumerates through the passthrough.
     with group("Testing Target-C to Target-A data passthrough"):
-        set_boost_supply(5.0, 0.25)
-        connect_boost_supply_to('TARGET-C')
+        # Supply is already connected to CONTROL.
+        # Now connect it to TARGET-C also.
+        connect_boost_supply_to('CONTROL', 'TARGET-C')
         connect_host_to('TARGET-C')
         FX2_EN.high()
         loader = test_fx2_present()
@@ -199,7 +200,8 @@ def test(user_present: bool):
         handle.claimInterface(0)
         test_usb_hs_speed('TARGET-C', handle, 2, Range(35, 45))
         FX2_EN.low()
-        connect_boost_supply_to(None)
+        # Connect supply to CONTROL alone, disconnecting from TARGET-C.
+        connect_boost_supply_to('CONTROL')
 
     with group("Reconnecting to Apollo"):
         connect_host_to('CONTROL')
@@ -216,6 +218,11 @@ def test(user_present: bool):
                     test_vbus_distribution(
                         apollo, voltage, load_resistance,
                         load_pin, passthrough, input_port)
+        with group("Switching EUT back to DC-DC supply"):
+            set_boost_supply(5.0, 0.25)
+            connect_boost_supply_to('CONTROL')
+            test_vbus('CONTROL', Range(4.85, 5.05))
+            connect_host_supply_to(None)
 
     # Test all LEDs.
     with group("Testing LEDs"):

--- a/cynthion-test.py
+++ b/cynthion-test.py
@@ -117,6 +117,9 @@ def test(user_present: bool):
         # Check the voltage now reaches the EUT's TARGET-A port.
         test_voltage('TARGET_A_VBUS', Range(4.85, 5.05))
 
+        # Disconnect TARGET-C supply.
+        connect_boost_supply_to('CONTROL')
+
     # Check all PHY supply voltages.
     with group("Checking all PHY supply voltages"):
         for (testpoint, minimum, maximum) in phy_supplies:

--- a/tests.py
+++ b/tests.py
@@ -1038,10 +1038,9 @@ def test_supply_selection(apollo):
             enable_supply_input(apollo, 'CONTROL', True)
             test_voltage('+5V', high)
 
-        with group("Swap back to powering from host"):
-            set_boost_supply(4.5, 0.25)
-            connect_host_supply_to('CONTROL')
-            connect_boost_supply_to(None)
+        with group("Switching back to DC-DC supply"):
+            connect_host_supply_to(None)
+            set_boost_supply(5.0, 0.25)
 
 def test_cc_sbu_control(apollo, port):
     begin_cc_measurement(port)
@@ -1160,7 +1159,13 @@ def test_vbus_distribution(apollo, voltage, load_resistance,
 
         with group("Shutting down test"):
             if passthrough:
+                # Lower the DC-DC output voltage to 5V while still under load,
+                # so that the voltage falls rapidly, but keep the current
+                # limit set high enough not to trip with the load present.
+                set_boost_supply(5.0, 3.0)
+                # After removing the load, set the current limit back to normal.
                 set_pin(load_pin, False)
+                set_boost_supply(5.0, 0.25)
                 if apollo:
                     set_passthrough(apollo, input_port, False)
             connect_boost_supply_to(None)


### PR DESCRIPTION
During some parts of the test, we need an extra +5V supply to power the EUT whilst the programmable DC-DC supply on Tycho is being used to generate other voltages. In these phases, we power the EUT from the host's VBUS.

However, we want to minimise the use of the host's VBUS except during these tests, to avoid any dependency of the results on the host's VBUS output, and to avoid EUT faults affecting the host.

This PR ensures that the host supply is only used when actually necessary.