### PR TITLE
Test step numbering

### DIFF
--- a/cynthion-test.py
+++ b/cynthion-test.py
@@ -71,8 +71,7 @@ def test(user_present: bool):
             check_cc_resistances(port)
 
     # Check 60MHz clock.
-    # Disabled due to loading clock line, pending Sasserides changes.
-    # test_clock()
+    test_clock()
 
     # Flash Saturn-V bootloader to MCU via SWD.
     flash_bootloader()

--- a/cynthion-test.py
+++ b/cynthion-test.py
@@ -191,7 +191,7 @@ def test(user_present: bool):
         connect_boost_supply_to('CONTROL', 'TARGET-C')
         connect_host_to('TARGET-C')
         FX2_EN.high()
-        loader = test_fx2_present()
+        loader = find_device(0x04b4, 0x8613)
         bus = loader.getBusNumber()
         addr = loader.getDeviceAddress()
         path = f"/dev/bus/usb/{bus:03d}/{addr:03d}"

--- a/cynthion-test.py
+++ b/cynthion-test.py
@@ -271,6 +271,8 @@ def test(user_present: bool):
 
 if __name__ == "__main__":
     user_present = 'unattended' not in sys.argv[1:]
+    if user_present:
+        enable_numbering()
     try:
         test(user_present)
         ok("All tests completed")

--- a/formatting.py
+++ b/formatting.py
@@ -16,6 +16,9 @@ def todo(text):
 def info(text):
     return Fore.CYAN + str(text) + Style.RESET_ALL
 
+def result(text):
+    print(info(text) + ", ", end="")
+
 def ask(text):
     print()
     print(

--- a/formatting.py
+++ b/formatting.py
@@ -3,9 +3,23 @@ import colorama
 
 colorama.init()
 indent = 0
+numbering = False
+
+step = [0]
+
+def enable_numbering():
+    global numbering
+    numbering = True
 
 def msg(text, end, flush=False):
-    print(("  " * indent) + "• " + text + Style.RESET_ALL, end=end, flush=flush)
+    if numbering:
+        step[-1] += 1
+        step_text = ".".join(str(s) for s in step)
+        step_text += " " * (11 - len(step_text))
+        prefix = Fore.YELLOW + step_text + Style.RESET_ALL + "│ "
+    else:
+        prefix = ""
+    print(prefix + ("  " * indent ) + "• " + text + Style.RESET_ALL, end=end, flush=flush)
 
 def item(text):
     msg(text, "\n")
@@ -46,9 +60,11 @@ class group():
         global indent
         msg(self.text, ":\n")
         indent += 1
+        step.append(0)
         return self
     def __exit__(self, exc_type, exc_value, exc_tb):
         global indent
+        step.pop()
         indent -= 1
         return False
 

--- a/tests.py
+++ b/tests.py
@@ -557,10 +557,6 @@ def test_analyzer_present():
     with group(f"Checking for analyzer"):
         return find_device(0x1d50, 0x615b, "LUNA", "USB Analyzer")
 
-def test_fx2_present():
-    with group(f"Checking for FX2"):
-        return find_device(0x04b4, 0x8613)
-
 def simulate_program_button():
     with group(f"Simulating pressing the {info('PROGRAM')} button"):
         set_pin('nBTN_PROGRAM', False)

--- a/tests.py
+++ b/tests.py
@@ -459,6 +459,9 @@ def discharge(port):
     DISCHARGE.low()
 
 def test_clock():
+    # Test disabled pending Sasserides-A r1.0.1 boards with clock buffer.
+    todo(f"Checking frequency on {info('CLK')}")
+    return
     reference_hz = 204000000 // 10
     target_hz = 60000000
     tolerance_ppm = 100

--- a/tests.py
+++ b/tests.py
@@ -544,8 +544,8 @@ def test_apollo_present():
                     "Great Scott Gadgets",
                     "Apollo Debugger",
                     mcu_serial)
-    with task("Connecting to Apollo"):
-        apollo = ApolloDebugger()
+        with task("Connecting to Apollo"):
+            apollo = ApolloDebugger()
     return apollo
 
 def test_bridge_present():

--- a/tests.py
+++ b/tests.py
@@ -601,10 +601,11 @@ def test_jtag_scan(apollo):
             with apollo.jtag as jtag:
                 devices = [(device.idcode(), device.description())
                     for device in jtag.enumerate()]
-        for idcode, desc in devices:
-            item(f"Found {info(f'0x{idcode:8X}')}: {info(desc)}")
-        if devices != [(0x21111043, "Lattice LFE5U-12F ECP5 FPGA")]:
-            raise ValueError("JTAG scan chain did not include expected devices")
+            result(", ".join(
+                f"{info(f'0x{idcode:8X}')}: {info(desc)}"
+                    for idcode, desc in devices))
+            if devices != [(0x21111043, "Lattice LFE5U-12F ECP5 FPGA")]:
+                raise ValueError("JTAG scan chain did not include expected devices")
 
 def unconfigure_fpga(apollo):
     with apollo.jtag as jtag:


### PR DESCRIPTION
This PR adds a numbering scheme for all test steps.

In preparation for the numbering scheme, various changes have been made to the formatting of output text. The aims of these changes are:
- to avoid unnecessary levels of indentation/numbering,
- to ensure that all fallible I/O operations are appropriately associated with a numbered test step, and
- to ensure that all fallible operations explicitly report either an `OK` result or an in-range value.

Excerpt from numbered output:
```
1          │  • Setting up and checking test system:
1.1        │    • Checking software dependencies:
1.1.1      │      • Checking for gdb-multiarch... OK
1.1.2      │      • Checking for fxload... OK
1.2        │    • Checking for GreatFET:
1.2.1      │      • Looking for device with VID: 0x1d50, PID: 0x60e6... OK
1.2.2      │      • Checking manufacturer is Great Scott Gadgets... OK
1.2.3      │      • Checking product is GreatFET... OK
1.2.4      │      • Reading serial number... 000000000000000057cc67e6323f4157, OK
1.2.5      │      • Connecting to GreatFET... OK
1.2.6      │      • Checking GreatFET firmware version is git-v2021.2.1-65-g8d8be6f... OK
1.3        │    • Configuring GPIOs... OK
1.4        │    • Checking for 24V supply:
1.4.1      │      • Driving D_TEST_PLUS high... OK
1.4.2      │      • Checking voltage on D_TEST_PLUS is within 3.20 to 3.40 V: 3.31 V
1.4.3      │      • Releasing D_TEST_PLUS drive... OK
1.5        │    • Configuring DC-DC converter... OK
1.6        │    • Setting DC-DC converter to 5.00 V 0.10 A... OK
1.7        │    • Checking for Black Magic Probe:
1.7.1      │      • Looking for device with VID: 0x1d50, PID: 0x6018... OK
1.7.2      │      • Checking manufacturer is Black Magic Debug... OK
1.7.3      │      • Checking product is Black Magic Probe v1.9.1... OK
1.7.4      │      • Reading serial number... 98B6A4B5, OK
2          │  • Loading calibration data... OK
3          │  • Checking for shorts on all USB-C ports:
3.1        │    • Checking for shorts on CONTROL:
3.1.1      │      • Connecting tester D+/D- to CONTROL... OK
3.1.2      │      • Connecting tester CC/SBU lines to CONTROL... OK
```