### PR TITLE
Calibration improvements

### DIFF
--- a/calibrate.py
+++ b/calibrate.py
@@ -27,6 +27,7 @@ def calibrate():
 
     # Write out calibration.
     calibration = dict(
+        greatfet_serial=state.gf.serial_number(),
         voltage_scale_lower=scale_low,
         voltage_scale_upper=scale_high,
     )

--- a/calibrate.py
+++ b/calibrate.py
@@ -19,6 +19,10 @@ def calibrate():
         scale_low = 5.0 / test_vbus('TARGET-C', Range(4.9, 5.1))
         item(f"Calibration factor: {info(scale_low)}")
 
+    with group("Calibrating current offset"):
+        current_offset = test_boost_current(Range(0, 0.15))
+        item(f"Offset: {info(current_offset)}")
+
     # Increase voltage to 15V and repeat.
     with group("Calibrating high range"):
         set_boost_supply(15.0, 0.1)
@@ -30,6 +34,7 @@ def calibrate():
         greatfet_serial=state.gf.serial_number(),
         voltage_scale_lower=scale_low,
         voltage_scale_upper=scale_high,
+        current_offset=current_offset,
     )
     pickle.dump(calibration, open('calibration.dat', 'wb'))
 

--- a/state.py
+++ b/state.py
@@ -28,5 +28,6 @@ boost_port = None
 calibration = dict(
     greatfet_serial = None,
     voltage_scale_upper = 1.0,
-    voltage_scale_lower = 1.0
+    voltage_scale_lower = 1.0,
+    current_offset = 0.0,
 )

--- a/state.py
+++ b/state.py
@@ -26,6 +26,7 @@ boost_port = None
 
 # Calibration data.
 calibration = dict(
+    greatfet_serial = None,
     voltage_scale_upper = 1.0,
     voltage_scale_lower = 1.0
 )

--- a/tests.py
+++ b/tests.py
@@ -200,12 +200,15 @@ def load_calibration():
         except Exception:
             raise CalibrationError("Loading calibration file failed")
         for field in (
+            'greatfet_serial',
             'voltage_scale_lower',
             'voltage_scale_upper',
         ):
             if field not in state.calibration:
                 raise CalibrationError(
                     f"Field '{field}' not found in calibration data")
+        if state.calibration['greatfet_serial'] != state.gf.serial_number():
+            raise CalibrationError("Calibration data is for a different tester")
 
 class short_check():
 

--- a/tests.py
+++ b/tests.py
@@ -1123,6 +1123,7 @@ def test_vbus_distribution(apollo, voltage, load_resistance,
     output_cable_resistance = Range(0.03, 0.05)
     scale_error = Range(0.98, 1.02)
     offset_error = Range(-0.01, 0.01)
+    boost_current_extra_error = Range(-0.01, 0.01)
 
     if passthrough:
         total_resistance = sum([
@@ -1184,7 +1185,7 @@ def test_vbus_distribution(apollo, voltage, load_resistance,
 
             with group("Checking voltages and positive current on input"):
                 test_vbus(input_port, v_sp)
-                test_boost_current(i_on)
+                test_boost_current(i_on + boost_current_extra_error)
                 test_eut_voltage(apollo, input_port, v_ip)
                 test_eut_current(apollo, input_port, i_on)
 

--- a/tests.py
+++ b/tests.py
@@ -203,6 +203,7 @@ def load_calibration():
             'greatfet_serial',
             'voltage_scale_lower',
             'voltage_scale_upper',
+            'current_offset',
         ):
             if field not in state.calibration:
                 raise CalibrationError(
@@ -376,7 +377,8 @@ def test_boost_current(expected):
     mux_disconnect()
     shunt_voltage = cdc_voltage * 0.05
     shunt_resistance = 0.01
-    shunt_current = max(shunt_voltage / shunt_resistance - 0.06, 0)
+    offset = state.calibration['current_offset']
+    shunt_current = max(shunt_voltage / shunt_resistance - offset, 0)
     channel = vbus_channels[state.boost_port]
     return test_value("current", channel, shunt_current, 'A', expected)
 


### PR DESCRIPTION
A few calibration improvements:

1. Record the serial number of the GreatFET in the calibration file, and check it on load. This prevents the wrong calibration being used if the test system connected to the host is replaced.

2. Calibrate the measurement offset for the DC-DC converter's output current. Previously a fixed value was used, but this has been found to vary a bit over Tycho units.

3. Allow a wider margin when making current measurements via the DC-DC converter, since even with the additional calibration it is only a fairly rough measurement.