### PR TITLE
Adjustments for Tycho r2.0.1 and Sasserides-A r1.0.1

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -483,9 +483,6 @@ def discharge(port):
     DISCHARGE.low()
 
 def test_clock():
-    # Test disabled pending Sasserides-A r1.0.1 boards with clock buffer.
-    todo(f"Checking frequency on {info('CLK')}")
-    return
     reference_hz = 204000000 // 10
     target_hz = 60000000
     tolerance_ppm = 100

--- a/tests.py
+++ b/tests.py
@@ -1124,7 +1124,7 @@ def test_vbus_distribution(apollo, voltage, load_resistance,
     output_cable_resistance = Range(0.03, 0.05)
     scale_error = Range(0.98, 1.02)
     offset_error = Range(-0.01, 0.01)
-    boost_current_extra_error = Range(-0.01, 0.01)
+    boost_current_extra_error = Range(-0.02, 0.02)
 
     if passthrough:
         total_resistance = sum([


### PR DESCRIPTION
Two changes here:

- Re-enable the clock frequency test, now that we have the clock buffer on Sasserides r1.0.1 to reduce loading on the EUT clock signal. Note to @grvvy: this will work on the new Sasserides stack I sent you, but not on your old one. When working with a Sasserides-A r1.0.0, keep the lines disabling the clock test in your local version. 

- Increase the error margin for current measurements taken via the DC-DC converter. On some of the Tycho r2.0.1 units, measurements could sometimes be just outside the existing margin even after calibration.