### PR TITLE
Increase CC resistance high threshold

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -332,7 +332,7 @@ def end_cc_measurement():
     connect_tester_cc_sbu_to(None)
 
 def check_cc_resistances(port):
-    expected_resistance = 5.1 * Range(0.9, 1.1)
+    expected_resistance = 5.1 * Range(0.9, 1.15)
     with group(f"Checking CC resistances on {info(port)}"):
         begin_cc_measurement(port)
         for pin in ('CC1', 'CC2'):


### PR DESCRIPTION
We're seeing CC 5.1k resistances on CONTROL (with fixed resistors) average about 5.4k with a few failures slightly above the +10% threshold. The spec allows up to 20% error, so we're increasing the high threshold from +10% to +15k.