### PR TITLE
Allow extra current error

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -1194,6 +1194,7 @@ def test_vbus_distribution(apollo, voltage, load_resistance,
     scale_error = Range(0.98, 1.02)
     offset_error = Range(-0.01, 0.01)
     boost_current_extra_error = Range(-0.02, 0.05)
+    current_extra_error = Range(-0.01, 0.01)
 
     if passthrough:
         total_resistance = sum([
@@ -1257,7 +1258,7 @@ def test_vbus_distribution(apollo, voltage, load_resistance,
                 test_vbus(input_port, v_sp)
                 test_boost_current(i_on + boost_current_extra_error)
                 test_eut_voltage(apollo, input_port, v_ip)
-                test_eut_current(apollo, input_port, i_on)
+                test_eut_current(apollo, input_port, i_on + current_extra_error)
 
             with group("Checking voltages and negative current on output"):
                 discharge = not passthrough


### PR DESCRIPTION
Allow a bit of extra current measurement error to address FAIL 42.6.4.4-HIG and FAIL 42.6.4.4-LOW.
