### PR TITLE
Revert baud rate mismatch workaround

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -598,20 +598,10 @@ def test_bridge_present():
 def test_analyzer_present():
     with group(f"Checking for analyzer"):
         serial = hex(state.flash_serial)[2:].lower()
-        try:
-            find_device(0x1d50, 0x615b,
-                        "Cynthion Project",
-                        "USB Analyzer",
-                        serial)
-        except:
-            state.step[1] -= 2
-            sleep(10)
-            simulate_reset_button()
-            sleep(1)
-            return find_device(0x1d50, 0x615b,
-                               "Cynthion Project",
-                               "USB Analyzer",
-                               serial)
+        return find_device(0x1d50, 0x615b,
+                           "Cynthion Project",
+                           "USB Analyzer",
+                           serial)
 
 def simulate_program_button():
     with group(f"Simulating pressing the {info('PROGRAM')} button"):


### PR DESCRIPTION
The workaround has caused some problems with other types of failures due to the `except`. It could be fixed, but it is no  longer needed now that Apollo is counting pulses instead of using UART RX.