### PR TITLE
Pause to avoid power glitch

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -374,6 +374,7 @@ def connect_boost_supply_to(*ports):
             BOOST_VBUS_AUX.high()
         if 'TARGET-C' in ports:
             BOOST_VBUS_TC.high()
+        sleep(0.1)
         if 'CONTROL' not in ports:
             BOOST_VBUS_CON.low()
         if 'AUX' not in ports:


### PR DESCRIPTION
It seems that power glitches can happen (rarely) when switching the supply from one EUT port to another. Hopefully a short pause between connecting the new port and disconnecting the old port will help.

Previously we tried pressing PROGRAM to ensure Apollo has CONTROL after the FX2 test, but this also halted the FPGA. Rather than extending that workaround with an additional step to reconfigure the FPGA, we thought it would be better to try to avoid the power glitch in the first place.