### PR TITLE
Clone submodules non-recursively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ analyzer.bit: $(TIMESTAMP)
 environment:
 	python -m venv environment
 
-$(TIMESTAMP): environment
+$(TIMESTAMP): environment submodule-checkout
 	environment/bin/python -m pip install --upgrade pip
 	$(ENV_INSTALL) -e dependencies/pyfwup
 	$(ENV_INSTALL) -e dependencies/libgreat/host
@@ -99,3 +99,8 @@ clean:
 	rm -f $(BOOTLOADER)
 	rm -rf $(GF_FW)/build
 	rm -rf environment
+
+submodule-checkout:
+	git submodule init && git submodule update
+	cd dependencies/apollo && git submodule init && git submodule update && cd ../..
+	cd dependencies/greatfet && git submodule init && git submodule update && cd ../..

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ This repository contains software for testing a [Cynthion](https://github.com/gr
 ## Setup
 
 ```sh
-# Check out the repository, including submodules:
-git clone --recurse-submodules https://github.com/greatscottgadgets/cynthion-test
+# Check out the repository:
+git clone https://github.com/greatscottgadgets/cynthion-test
 cd cynthion-test
 
 # Install pre-requisites


### PR DESCRIPTION
This avoids the lengthy and unnecessary recursive clone of tinyusb.